### PR TITLE
Move absolute event info to a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,187 @@ Elixir interface to Linux input event devices. Using `input_event`, you can
 
 This library is intended for use with Nerves. If you're running a desktop Linux
 distribution, this can still work, but you'll likely want to use a higher level
-API to receiving events.
+API for receiving events.
 
 ## Usage
 
 InputEvent can be used to monitor `/dev/input/event*` devices and report decoded
 data to the parent process.
 
-Start by looking for the device you want to monitor.
+Start by looking for the device you want to monitor:
 
 ```elixir
 iex> InputEvent.enumerate
 [
   {"/dev/input/event0",
    %InputEvent.Info{
-     bus: 25,
+     bus: 0,
      input_event_version: "1.0.1",
-     name: "Power Button",
-     product: 1,
-     report_info: [ev_key: [:key_power]],
+     name: "FT5406 memory based driver",
+     product: 0,
+     report_info: [
+       ev_abs: [
+         abs_x: %{flat: 0, fuzz: 0, max: 800, min: 0, resolution: 0, value: 0},
+         abs_y: %{flat: 0, fuzz: 0, max: 480, min: 0, resolution: 0, value: 0},
+         abs_mt_slot: %{
+           flat: 0,
+           fuzz: 0,
+           max: 9,
+           min: 0,
+           resolution: 0,
+           value: 0
+         },
+         abs_mt_position_x: %{
+           flat: 0,
+           fuzz: 0,
+           max: 800,
+           min: 0,
+           resolution: 0,
+           value: 0
+         },
+         abs_mt_position_y: %{
+           flat: 0,
+           fuzz: 0,
+           max: 480,
+           min: 0,
+           resolution: 0,
+           value: 0
+         },
+         abs_mt_tracking_id: %{
+           flat: 0,
+           fuzz: 0,
+           max: 65535,
+           min: 0,
+           resolution: 0,
+           value: 0
+         }
+       ],
+       ev_key: [:btn_touch]
+     ],
      vendor: 0,
      version: 0
-   }},
+   }}
+]
+```
+
+There's a touchscreen at `/dev/input/event0`, so let's open it:
+
+```elixir
+iex> InputEvent.start_link("/dev/input/event0")
+{:ok, #PID<0.197.0>}
+```
+
+Touch the screen to test
+
+```elixir
+iex> flush
+{:input_event, "/dev/input/event0",
+ [
+   {:ev_abs, :abs_mt_tracking_id, 1},
+   {:ev_abs, :abs_mt_position_x, 350},
+   {:ev_abs, :abs_mt_position_y, 119},
+   {:ev_key, :btn_touch, 1},
+   {:ev_abs, :abs_x, 350},
+   {:ev_abs, :abs_y, 119}
+ ]}
+{:input_event, "/dev/input/event0",
+ [
+   {:ev_abs, :abs_mt_position_x, 352},
+   {:ev_abs, :abs_mt_position_y, 122},
+   {:ev_abs, :abs_x, 352},
+   {:ev_abs, :abs_y, 122}
+ ]}
+{:input_event, "/dev/input/event0",
+ [{:ev_abs, :abs_mt_tracking_id, -1}, {:ev_key, :btn_touch, 0}]}
+{:input_event, "/dev/input/event0",
+ [
+   {:ev_abs, :abs_mt_tracking_id, 2},
+   {:ev_abs, :abs_mt_position_x, 361},
+   {:ev_abs, :abs_mt_position_y, 361},
+   {:ev_abs, :abs_mt_slot, 1},
+   {:ev_abs, :abs_mt_tracking_id, 3},
+   {:ev_abs, :abs_mt_position_x, 425},
+   {:ev_abs, :abs_mt_position_y, 139},
+   {:ev_key, :btn_touch, 1},
+   {:ev_abs, :abs_x, 361},
+   {:ev_abs, :abs_y, 361}
+ ]}
+{:input_event, "/dev/input/event0", [{:ev_abs, :abs_mt_position_y, 142}]}
+{:input_event, "/dev/input/event0",
+ [
+   {:ev_abs, :abs_mt_slot, 0},
+   {:ev_abs, :abs_mt_position_y, 363},
+   {:ev_abs, :abs_mt_slot, 1},
+   {:ev_abs, :abs_mt_position_x, 427},
+   {:ev_abs, :abs_mt_position_y, 147},
+   {:ev_abs, :abs_y, 363}
+ ]}
+{:input_event, "/dev/input/event0",
+ [{:ev_abs, :abs_mt_position_x, 428}, {:ev_abs, :abs_mt_position_y, 149}]}
+{:input_event, "/dev/input/event0",
+ [
+   {:ev_abs, :abs_mt_slot, 0},
+   {:ev_abs, :abs_mt_tracking_id, -1},
+   {:ev_abs, :abs_mt_slot, 1},
+   {:ev_abs, :abs_mt_tracking_id, -1},
+   {:ev_key, :btn_touch, 0}
+ ]}
+:ok
+```
+
+## Examples
+
+Enumerating attached devices can be really helpful in figuring out what kind of
+messages that you'll be sent. Here are other examples:
+
+### Keyboard
+
+```elixir
+  {"/dev/input/event3",
+   %InputEvent.Info{
+     bus: 3,
+     input_event_version: "1.0.1",
+     name: "Logitech K520",
+     product: 8209,
+     report_info: [
+       ev_rep: [250, :rep_delay, 33, :rep_delay],
+       ev_led: [:led_numl, :led_capsl, :led_scrolll, :led_compose, :led_kana],
+       ev_msc: [:msc_scan],
+       ev_abs: [
+         abs_volume: %{
+           flat: 0,
+           fuzz: 0,
+           max: 652,
+           min: 1,
+           resolution: 0,
+           value: 0
+         }
+       ],
+       ev_rel: [:rel_hwheel],
+       ev_key: [:key_esc, :key_1, :key_2, :key_3, :key_4, :key_5, :key_6,
+        :key_7, :key_8, :key_9, :key_0, :key_minus, :key_equal, :key_backspace,
+        :key_tab, :key_q, :key_w, :key_e, :key_r, :key_t, :key_y, :key_u,
+        :key_i, :key_o, :key_p, :key_leftbrace, :key_rightbrace, ...]
+     ],
+     vendor: 1133,
+     version: 273
+   }}
+```
+
+Events from a keyboard look like:
+
+```elixir
+{:input_event, "/dev/input/event3",
+ [{:ev_msc, :msc_scan, 458761}, {:ev_key, :key_f, 1}]}
+{:input_event, "/dev/input/event3",
+ [{:ev_msc, :msc_scan, 458761}, {:ev_key, :key_f, 0}]}
+```
+
+The 1 and 0 indicate key down and key up.
+
+### Mouse
+
+```elixir
   {"/dev/input/event2",
    %InputEvent.Info{
      bus: 3,
@@ -47,84 +206,103 @@ iex> InputEvent.enumerate
      ],
      vendor: 1133,
      version: 273
-   }},
-  {"/dev/input/event3",
+   }}
+```
+
+Events from a mouse look like:
+
+```elixir
+{:input_event, "/dev/input/event2", [{:ev_rel, :rel_x, 12}]}
+{:input_event, "/dev/input/event2",
+ [{:ev_rel, :rel_x, 14}, {:ev_rel, :rel_y, -1}]}
+```
+
+Notice that if there's no movement in an axis that you won't get an update for that axis.
+
+### Joystick
+
+```elixir
+  {"/dev/input/event15",
    %InputEvent.Info{
      bus: 3,
      input_event_version: "1.0.1",
-     name: "Logitech K520",
-     product: 8209,
+     name: "Microsoft X-Box 360 pad",
+     product: 654,
      report_info: [
-       ev_rep: [250, :rep_delay, 33, :rep_delay],
-       ev_led: [:led_numl, :led_capsl, :led_scrolll, :led_compose, :led_kana],
-       ev_msc: [:msc_scan],
-       ev_abs: [{:abs_volume, 0, 1, 652, 0, 0, 0}],
-       ev_rel: [:rel_hwheel],
-       ev_key: [:key_esc, :key_1, :key_2, :key_3, :key_4, :key_5, :key_6,
-        :key_7, :key_8, :key_9, :key_0, :key_minus, :key_equal, :key_backspace,
-        :key_tab, :key_q, :key_w, :key_e, :key_r, :key_t, :key_y, :key_u,
-        :key_i, :key_o, :key_p, :key_leftbrace, :key_rightbrace, :key_enter,
-        ...]
+       ev_ff: 'PQXYZ`',
+       ev_abs: [
+         abs_x: %{
+           flat: 128,
+           fuzz: 16,
+           max: 32767,
+           min: -32768,
+           resolution: 0,
+           value: 0
+         },
+         abs_y: %{
+           flat: 128,
+           fuzz: 16,
+           max: 32767,
+           min: -32768,
+           resolution: 0,
+           value: 0
+         },
+         abs_z: %{flat: 0, fuzz: 0, max: 255, min: 0, resolution: 0, value: 0},
+         abs_rx: %{
+           flat: 128,
+           fuzz: 16,
+           max: 32767,
+           min: -32768,
+           resolution: 0,
+           value: 0
+         },
+         abs_ry: %{
+           flat: 128,
+           fuzz: 16,
+           max: 32767,
+           min: -32768,
+           resolution: 0,
+           value: 0
+         },
+         abs_rz: %{flat: 0, fuzz: 0, max: 255, min: 0, resolution: 0, value: 0},
+         abs_hat0x: %{
+           flat: 0,
+           fuzz: 0,
+           max: 1,
+           min: -1,
+           resolution: 0,
+           value: 0
+         },
+         abs_hat0y: %{
+           flat: 0,
+           fuzz: 0,
+           max: 1,
+           min: -1,
+           resolution: 0,
+           value: 0
+         }
+       ],
+       ev_key: [:btn_a, :btn_b, :btn_x, :btn_y, :btn_tl, :btn_tr, :btn_select,
+        :btn_start, :btn_mode, :btn_thumbl, :btn_thumbr]
      ],
-     vendor: 1133,
-     version: 273
-   }},
-  {"/dev/input/event4",
-   %InputEvent.Info{
-     bus: 0,
-     input_event_version: "1.0.1",
-     name: "HD-Audio Generic Front Mic",
-     product: 0,
-     report_info: [ev_sw: [:sw_microphone_insert]],
-     vendor: 0,
-     version: 0
-   }},
-  {"/dev/input/event11",
-   %InputEvent.Info{
-     bus: 0,
-     input_event_version: "1.0.1",
-     name: "ELAN Touchscreen",
-     product: 0,
-     report_info: ...,
-     vendor: 0,
-     version: 0
-  }}
-]
+     vendor: 1118,
+     version: 272
+   }}
 ```
 
-There's a touchscreen at `/dev/input/event11`, so let's open it:
+### Power button
 
 ```elixir
-iex> InputEvent.start_link("/dev/input/event11")
-{:ok, #PID<0.197.0>}
+  {"/dev/input/event0",
+   %InputEvent.Info{
+     bus: 25,
+     input_event_version: "1.0.1",
+     name: "Power Button",
+     product: 1,
+     report_info: [ev_key: [:key_power]],
+     vendor: 0,
+     version: 0
+   }}
 ```
 
-Touch the screen to test
-
-```elixir
-iex> flush
-{:input_event, "/dev/input/event11",
- [
-   {:ev_abs, :abs_mt_tracking_id, 1},
-   {:ev_abs, :abs_mt_position_x, 2630},
-   {:ev_abs, :abs_mt_position_y, 1141},
-   {:ev_abs, :abs_mt_tool_x, 2630},
-   {:ev_abs, :abs_mt_tool_y, 1141},
-   {:ev_abs, :abs_mt_touch_major, 7},
-   {:ev_abs, :abs_mt_touch_minor, 4},
-   {:ev_key, :btn_touch, 1},
-   {:ev_abs, :abs_x, 2630},
-   {:ev_abs, :abs_y, 1141}
- ]}
-{:input_event, "/dev/input/event11",
- [{:ev_abs, :abs_mt_touch_major, 8}, {:ev_abs, :abs_mt_touch_minor, 5}]}
-{:input_event, "/dev/input/event11", [{:ev_abs, :abs_mt_touch_major, 9}]}
-{:input_event, "/dev/input/event11", [{:ev_abs, :abs_mt_touch_major, 8}]}
-{:input_event, "/dev/input/event11",
- [{:ev_abs, :abs_mt_touch_major, 7}, {:ev_abs, :abs_mt_touch_minor, 4}]}
-{:input_event, "/dev/input/event11",
- [{:ev_abs, :abs_mt_touch_major, 5}, {:ev_abs, :abs_mt_touch_minor, 3}]}
-{:input_event, "/dev/input/event11",
- [{:ev_abs, :abs_mt_tracking_id, -1}, {:ev_key, :btn_touch, 0}]}
-:ok
-```
+The power button input device works just like a one-button keyboard.

--- a/lib/input_event/info.ex
+++ b/lib/input_event/info.ex
@@ -27,9 +27,11 @@ defmodule InputEvent.Info do
   end
 
   defp decode_codes(0x03, raw_report_info) do
-    for <<code::native-16, value::native-32, min::native-32, max::native-32, fuzz::native-32,
-          flat::native-32, resolution::native-32 <- raw_report_info>> do
-      {InputEvent.Types.decode_code(0x03, code), value, min, max, fuzz, flat, resolution}
+    for <<code::native-16, value::signed-native-32, min::signed-native-32, max::signed-native-32,
+          fuzz::signed-native-32, flat::signed-native-32,
+          resolution::signed-native-32 <- raw_report_info>> do
+      {InputEvent.Types.decode_code(0x03, code),
+       %{value: value, min: min, max: max, fuzz: fuzz, flat: flat, resolution: resolution}}
     end
   end
 

--- a/test/input_event/info_test.exs
+++ b/test/input_event/info_test.exs
@@ -13,6 +13,8 @@ defmodule InputEvent.InfoTest do
              3,
              <<0x20::native-16, 1::native-32, 2::native-32, 3::native-32, 4::native-32,
                5::native-32, 6::native-32>>
-           ) == {:ev_abs, [{:abs_volume, 1, 2, 3, 4, 5, 6}]}
+           ) ==
+             {:ev_abs,
+              [{:abs_volume, %{flat: 5, fuzz: 4, max: 3, min: 2, resolution: 6, value: 1}}]}
   end
 end


### PR DESCRIPTION
It was in a tuple. Moving it to a map makes it easier to understand. For
example, in the following touchscreen example, it's easier to see that
it's an 800x480 screen that supports multitouch (10-finger!?!):

```elixir
  {"/dev/input/event0",
   %InputEvent.Info{
     bus: 0,
     input_event_version: "1.0.1",
     name: "FT5406 memory based driver",
     product: 0,
     report_info: [
       ev_abs: [
         abs_x: %{flat: 0, fuzz: 0, max: 800, min: 0, resolution: 0, value: 0},
         abs_y: %{flat: 0, fuzz: 0, max: 480, min: 0, resolution: 0, value: 0},
         abs_mt_slot: %{
           flat: 0,
           fuzz: 0,
           max: 9,
           min: 0,
           resolution: 0,
           value: 0
         },
         abs_mt_position_x: %{
           flat: 0,
           fuzz: 0,
           max: 800,
           min: 0,
           resolution: 0,
           value: 0
         },
         abs_mt_position_y: %{
           flat: 0,
           fuzz: 0,
           max: 480,
           min: 0,
           resolution: 0,
           value: 0
         },
         abs_mt_tracking_id: %{
           flat: 0,
           fuzz: 0,
           max: 65535,
           min: 0,
           resolution: 0,
           value: 0
         }
       ],
       ev_key: [:btn_touch]
     ],
     vendor: 0,
     version: 0
   }}
```

This had a ripple effect on example verbosity in the docs so I
reorganized a little.