### PR TITLE
Remove chown/chmod/askpass from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,6 @@ DEFAULT_TARGETS ?= $(PREFIX) $(PREFIX)/input_event
 LDFLAGS +=
 CFLAGS += -std=gnu99
 
-# If not cross-compiling, then run sudo by default
-ifeq ($(origin CROSSCOMPILE), undefined)
-SUDO_ASKPASS ?= /usr/bin/ssh-askpass
-SUDO ?= sudo
-else
-# If cross-compiling, then permissions need to be set some build system-dependent way
-SUDO ?= true
-endif
-
 # Enable for debug messages
 #CFLAGS += -DDEBUG
 
@@ -60,8 +51,6 @@ $(PREFIX) $(BUILD):
 
 $(PREFIX)/input_event: $(OBJ)
 	$(CC) $^ $(LDFLAGS) -o $@
-	# For host builds, setuid root the input_event binary so that it can read /dev/input/event*
-	SUDO_ASKPASS=$(SUDO_ASKPASS) $(SUDO) -- sh -c 'chown root:root $@; chmod +s $@'
 
 clean:
 	rm -f $(PREFIX)/input_event $(BUILD)/*.o

--- a/README.md
+++ b/README.md
@@ -306,3 +306,10 @@ Notice that if there's no movement in an axis that you won't get an update for t
 ```
 
 The power button input device works just like a one-button keyboard.
+
+### Permissions
+To be able to read from `/dev/input/event*` you need to add user to the `input` group:
+```
+$ sudo usermod -a -G input <username>
+```
+And restart user session.


### PR DESCRIPTION
### Summary

Currently `Makefile` triggers ownership change of `_build/dev/lib/input_event/priv/input_event` to be able to read from `/dev/input/event*`. This requires `root` permissions and involves `sudo/askpass` to get library compiled.

On many linux distros `askpass` is not installed which causes following error during `mix compile`:
```
SUDO_ASKPASS=/usr/bin/ssh-askpass sudo -- sh -c 'chown root:root /home/cfx/devel/expi/_build/dev/lib/input_event/priv/input_event; chmod +s /home/cfx/devel/expi/_build/dev/lib/input_event/priv/input_event'
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
sudo: a password is required
make: *** [Makefile:64: /home/cfx/devel/expi/_build/dev/lib/input_event/priv/input_event] Error 1
```

### Intended effect
- `input_event` compilation should not depend on external tools like `askpass`.
- setting permissions to `/dev/input/event*` should be done separately (e.g as a post-compilation process).

### How to test
1. Add user to `input` group (see addition in README.md).
2. Run `iex -S mix`
3. Execute `InputEvent.enumerate`. You should get list of different devices connected without any permission errors.

### Notes
Related issue: https://github.com/nerves-web-kiosk/input_event/issues/13