### PR TITLE
Add option to grab device

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,15 @@ Notice that if there's no movement in an axis that you won't get an update for t
 
 The power button input device works just like a one-button keyboard.
 
+## Grab device
+
+Devices can be grabbed to prevent output into other applications.
+
+```elixir
+iex> InputEvent.start_link(path: "/dev/input/event0", grab: true)
+{:ok, #PID<0.197.0>}
+```
+
 ### Permissions
 
 To be able to read from `/dev/input/event*` you need to add user to the `input`

--- a/src/input_event.c
+++ b/src/input_event.c
@@ -190,7 +190,7 @@ static void send_report_info(int fd)
 
 int main(int argc, char *argv[])
 {
-    if (argc != 2)
+    if (argc < 2)
         errx(EXIT_FAILURE, "Pass the device to monitor");
 
     const char *input_path = argv[1];
@@ -202,6 +202,10 @@ int main(int argc, char *argv[])
     send_name(fd);
     send_id(fd);
     send_report_info(fd);
+
+    if (argc == 3 && !strcmp(argv[2], "true"))
+        if (ioctl(fd, EVIOCGRAB, (void *)1) != 0)
+            errx(EXIT_FAILURE, "Failed to grab device");
 
     send_report(NULL, 0, INPUT_EVENT_READY, 0);
 


### PR DESCRIPTION
Added options to capture input and handle callbacks in another process, ref issue #8.

Grab device:
```elixir
InputEvent.start_link(path: "/path/to/device", grab: true)
```

Opening another pull request since #19 automatically closed when I force pushed to clean up commit history.