### PR TITLE
Support getting initial events on process start

### DIFF
--- a/c_src/input_event.c
+++ b/c_src/input_event.c
@@ -153,6 +153,10 @@ static void send_report_info(int fd)
     if (ioctl(fd, EVIOCGBIT(0, EV_MAX), bit[0]) < 0)
         err(EXIT_FAILURE, "EVIOCGBIT");
 
+    char key_bitmask[KEY_MAX / 8];
+    if (ioctl(fd, EVIOCGKEY(sizeof(key_bitmask)), key_bitmask) < 0)
+        err(EXIT_FAILURE, "EVIOCGKEY");
+
     for (uint16_t i = 1; i < EV_MAX; i++) {
         if (test_bit(i, bit[0]) && i != EV_REP) {
             if (ioctl(fd, EVIOCGBIT(i, KEY_MAX), bit[i]) < 0)
@@ -168,6 +172,10 @@ static void send_report_info(int fd)
                             err(EXIT_FAILURE, "EVIOCGABS(%d)", j);
                         for (int k = 0; k < 6; k++)
                             p = append_int32(p, abs[k]);
+                    } else {
+                        // Add initial value to the report in case user wants them
+                        uint16_t value = (key_bitmask[j / 8] & (1 << (j % 8))) != 0;
+                        p = append_uint16(p, value);
                     }
                 }
             }

--- a/test/input_event/info_test.exs
+++ b/test/input_event/info_test.exs
@@ -4,17 +4,28 @@ defmodule InputEvent.InfoTest do
   alias InputEvent.Info
 
   test "decodes code list" do
-    assert Info.decode_report_info(1, <<2::native-16, 3::native-16>>) ==
-             {:ev_key, [:key_1, :key_2]}
+    assert {report_info, initial_events} =
+             Info.decode_report_info(
+               1,
+               <<2::native-16, 1::native-16, 3::native-16, 0::native-16>>
+             )
+
+    assert {:ev_key, [:key_1, :key_2]} = report_info
+    assert [{:ev_key, :key_1, 1}, {:ev_key, :key_2, 0}] = initial_events
   end
 
   test "decodes abs code list" do
-    assert Info.decode_report_info(
-             3,
-             <<0x20::native-16, 1::native-32, 2::native-32, 3::native-32, 4::native-32,
-               5::native-32, 6::native-32>>
-           ) ==
-             {:ev_abs,
-              [{:abs_volume, %{flat: 5, fuzz: 4, max: 3, min: 2, resolution: 6, value: 1}}]}
+    assert {report_info, initial_events} =
+             Info.decode_report_info(
+               3,
+               <<0x20::native-16, 1::native-32, 2::native-32, 3::native-32, 4::native-32,
+                 5::native-32, 6::native-32>>
+             )
+
+    assert {:ev_abs,
+            [{:abs_volume, %{flat: 5, fuzz: 4, max: 3, min: 2, resolution: 6, value: 1}}]} =
+             report_info
+
+    assert [{:ev_abs, :abs_volume, 1}] = initial_events
   end
 end


### PR DESCRIPTION
Some cases may require you to know the state of a key on boot (or it would otherwise be helpful for tracking). This now reads that current state and provides an option to receive them as initial events when starting the InputEvent process