### PR TITLE
Ignore unexpected messages to GenServer

### DIFF
--- a/lib/input_event.ex
+++ b/lib/input_event.ex
@@ -7,6 +7,8 @@ defmodule InputEvent do
   alias InputEvent.Info
   alias InputEvent.Report
 
+  require Logger
+
   @typedoc "An unknown event type"
   @type type_number() :: 0..0xFFFF
   @typedoc "The type of event"
@@ -154,9 +156,8 @@ defmodule InputEvent do
   end
 
   def handle_info(other, state) do
-    IO.puts("Not expecting: #{inspect(other)}")
-    send(state.callback, {:input_event, state.path, :error})
-    {:stop, :error, state}
+    Logger.warning("InputEvent: ignoring #{inspect(other)}")
+    {:noreply, state}
   end
 
   defp process_notification(state, <<@input_event_report, _sub, raw_events::binary>>) do

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule InputEvent.MixProject do
   end
 
   def application do
-    []
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
This removes code that exits and changes an IO.puts to a log message
when it happens. This removes a case where the GenServer could be
restarted and adds a helpful log message.
