### PR TITLE
Properly enumerate key repeat settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ messages that you'll be sent. Here are other examples:
      name: "Logitech K520",
      product: 8209,
      report_info: [
-       ev_rep: [250, :rep_delay, 33, :rep_delay],
+       ev_rep: %{delay: 250, period: 33},
        ev_led: [:led_numl, :led_capsl, :led_scrolll, :led_compose, :led_kana],
        ev_msc: [:msc_scan],
        ev_abs: [

--- a/lib/input_event/info.ex
+++ b/lib/input_event/info.ex
@@ -42,6 +42,17 @@ defmodule InputEvent.Info do
     end
   end
 
+  defp decode_codes(0x14, raw_report_info) do
+    case raw_report_info do
+      <<rep_delay::native-32, rep_period::native-32, _::binary>> ->
+        %{delay: rep_delay, period: rep_period}
+
+      _ ->
+        # Not sure.
+        []
+    end
+  end
+
   defp decode_codes(raw_type, raw_report_info) do
     for <<code::native-16 <- raw_report_info>> do
       InputEvent.Types.decode_code(raw_type, code)

--- a/test/input_event/info_test.exs
+++ b/test/input_event/info_test.exs
@@ -8,6 +8,11 @@ defmodule InputEvent.InfoTest do
              {:ev_key, [:key_1, :key_2]}
   end
 
+  test "decodes rep info" do
+    assert Info.decode_report_info(20, <<238, 2, 0, 0, 144, 1, 0, 0>>) ==
+             {:ev_rep, %{delay: 750, period: 400}}
+  end
+
   test "decodes abs code list" do
     assert Info.decode_report_info(
              3,


### PR DESCRIPTION
This fixes an issue where key repeat settings get decoded like keys. Now
they're decoded as a map with keys `:delay` and `:period`.
