### PR TITLE
Don't send events when enumerating

### DIFF
--- a/lib/input_event.ex
+++ b/lib/input_event.ex
@@ -195,9 +195,15 @@ defmodule InputEvent do
   end
 
   defp process_notification(state, <<@input_event_report, _sub, raw_events::binary>>) do
-    Enum.each(Report.decode(raw_events), fn events ->
-      send(state.callback, {:input_event, state.path, events})
-    end)
+    callback = state.callback
+
+    if callback do
+      raw_events
+      |> Report.decode()
+      |> Enum.each(fn events ->
+        send(callback, {:input_event, state.path, events})
+      end)
+    end
 
     state
   end

--- a/lib/input_event/enumerate.ex
+++ b/lib/input_event/enumerate.ex
@@ -19,7 +19,7 @@ defmodule InputEvent.Enumerate do
   end
 
   defp get_info(path) do
-    {:ok, server} = InputEvent.start_link(path)
+    {:ok, server} = InputEvent.start_link(path: path, receiver: nil)
     info = InputEvent.info(server)
     InputEvent.stop(server)
     {path, info}


### PR DESCRIPTION
Active key presses would be sent when enumerating due to how enumeration
works. This isn't desirable, so add a way to run the InputEvent
GenServer that does everything except send events to a `:receiver`.
