### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # InputEvent
 
 [![Hex version](https://img.shields.io/hexpm/v/input_event.svg "Hex version")](https://hex.pm/packages/input_event)
-[![API docs](https://img.shields.io/hexpm/v/input_event.svg?label=hexdocs "API docs")](https://hexdocs.pm/input_event/InputEvent.html)
+[![API docs](https://img.shields.io/hexpm/v/input_event.svg?label=hexdocs "API docs")](https://input-event.hexdocs.pm/InputEvent.html)
 [![CircleCI](https://circleci.com/gh/nerves-web-kiosk/input_event.svg?style=svg)](https://circleci.com/gh/nerves-web-kiosk/input_event)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-web-kiosk/input_event)](https://api.reuse.software/info/github.com/nerves-web-kiosk/input_event)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://input-event.hexdocs.pm/InputEvent.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>